### PR TITLE
OB-84-관리자-매점-기능과-관리자-세션-연동

### DIFF
--- a/src/main/java/com/oneteam/dormeaseadmin/admin/member/MemberInterceptor.java
+++ b/src/main/java/com/oneteam/dormeaseadmin/admin/member/MemberInterceptor.java
@@ -13,7 +13,7 @@ public class MemberInterceptor implements HandlerInterceptor {
         MemberDto loginedMemberDto = (MemberDto) session.getAttribute("loginedMemberDto");
 
         if(loginedMemberDto == null) {
-            response.sendRedirect(request.getContextPath() + "/admin/member/login_form");
+            response.sendRedirect(request.getContextPath() + "/admin/member/loginForm");
             return false;
         } else {
             return true;

--- a/src/main/java/com/oneteam/dormeaseadmin/config/WebMvcConfig.java
+++ b/src/main/java/com/oneteam/dormeaseadmin/config/WebMvcConfig.java
@@ -20,7 +20,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry){
         registry.addInterceptor(new MemberInterceptor())
-                .addPathPatterns("/admin/member/modify_form");
+                .addPathPatterns(
+                        "/admin/member/modify_form",
+                        "/product/**"
+                        );
     }
 
 }

--- a/src/main/java/com/oneteam/dormeaseadmin/product/IProductMapper.java
+++ b/src/main/java/com/oneteam/dormeaseadmin/product/IProductMapper.java
@@ -1,6 +1,7 @@
 package com.oneteam.dormeaseadmin.product;
 
 import com.oneteam.dormeaseadmin.admin.member.MemberDto;
+import com.oneteam.dormeaseadmin.admin.school.SchoolDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -37,4 +38,9 @@ public interface IProductMapper {
     //전체 관리자용
     public List<ProductNoticeDto> productNoticeList(ProductListDto productListDto);
     public int productNoticeListCnt(String keyWord);
+
+    ////-----///
+
+    //학교 관리를 위한 추가 기능 (학교 관리자 용)
+    public SchoolDto findSchoolByCode(MemberDto loginedMemberDto);
 }

--- a/src/main/java/com/oneteam/dormeaseadmin/product/ProductService.java
+++ b/src/main/java/com/oneteam/dormeaseadmin/product/ProductService.java
@@ -1,10 +1,10 @@
 package com.oneteam.dormeaseadmin.product;
 
 import com.oneteam.dormeaseadmin.admin.member.MemberDto;
+import com.oneteam.dormeaseadmin.admin.school.SchoolDto;
 import com.oneteam.dormeaseadmin.utils.pagination.Criteria;
 import com.oneteam.dormeaseadmin.utils.pagination.PageMakerDto;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -85,9 +85,11 @@ public class ProductService {
         Map<String, Object> item = new HashMap<>();
         ProductRegistDto productRegistDto = new ProductRegistDto();
         productRegistDto.setProduct_name(productName);
+
         productRegistDto.setZip_code(productMapper.selectSchoolZipCodeByAdmin(loginedMemberDto));
 
         int countExist = productMapper.isExistDatabase(productRegistDto);
+
         item.put("countExist", countExist);
 
         return item;
@@ -212,4 +214,10 @@ public class ProductService {
         return list;
     }
 
+    // 학교 이름 찾기
+    public SchoolDto findSchoolName(MemberDto loginedMemberDto) {
+        log.info("SchoolDto()");
+
+        return productMapper.findSchoolByCode(loginedMemberDto);
+    }
 }

--- a/src/main/resources/mybatis/mappers/ProductMapper.xml
+++ b/src/main/resources/mybatis/mappers/ProductMapper.xml
@@ -5,6 +5,13 @@
 
 <mapper namespace="com.oneteam.dormeaseadmin.product.IProductMapper">
 
+    <!-- 컨벤션 중 추가 기능 -->
+    <select id="findSchoolByCode" resultType="com.oneteam.dormeaseadmin.admin.school.SchoolDto">
+        SELECT *
+        FROM schoolInfo
+        WHERE school_code = #{school_no}
+    </select>
+
     <!--  전체 관리자 용  -->
     <insert id="insertNotice" parameterType="com.oneteam.dormeaseadmin.product.ProductDto">
         INSERT INTO
@@ -49,7 +56,7 @@
     <!--  학교 관리자 용  -->
     <select id="selectSchoolZipCodeByAdmin" parameterType="com.oneteam.dormeaseadmin.admin.member.MemberDto" resultType="String">
         SELECT
-            si.zip_code
+            DISTINCT si.zip_code
         FROM
             admin a
         JOIN
@@ -70,7 +77,7 @@
 
     <select id="selectSchoolZipCodeAndName" parameterType="com.oneteam.dormeaseadmin.product.ProductRegistDto" resultType="com.oneteam.dormeaseadmin.product.ProductRegistDto">
         SELECT
-            si.zip_code,
+            DISTINCT si.zip_code,
             si.school_name
         FROM
             admin a

--- a/src/main/resources/templates/include/adminProductList_js.html
+++ b/src/main/resources/templates/include/adminProductList_js.html
@@ -83,17 +83,26 @@ function unRegistProductAdmin(){
 
     $(document).on('click', '#section_wrap > div.product_list > table tbody tr td a.unRegist', function(e){
 
-        let no = $(this).data('no'); // data-no 속성에서 값을 가져옴
-        let product_name = $(this).data('product_name'); // data-product_name 속성에서 값을 가져옴
-        let result = confirm('정말 ' + product_name + ' 을(를) 삭제하시겠습니까?');
+        let adminId = $(this).data('adminid');
+        let loginedId = $(this).data('loginedid');
+        if(adminId == loginedId){   //등록자와 로그인한 사람이 같아야 삭제가능
+            let no = $(this).data('no'); // data-no 속성에서 값을 가져옴
+            let product_name = $(this).data('product_name'); // data-product_name 속성에서 값을 가져옴
+            let result = confirm('정말 ' + product_name + ' 을(를) 삭제하시겠습니까?');
 
-        if (result) {
-            // URL에 파라미터를 추가하여 새로운 URL 생성
-            let newUrl = '/product/unRegistProductAdmin?no=' + no;
+            if (result) {
+                // URL에 파라미터를 추가하여 새로운 URL 생성
+                let newUrl = '/product/unRegistProductAdmin?no=' + no;
 
-            // 새로운 URL로 이동
-            location.href = newUrl;
+                // 새로운 URL로 이동
+                location.href = newUrl;
+            }
         }
+        else{
+            alert('삭제 권한이 없습니다.');
+        }
+
+
 
     })
 }

--- a/src/main/resources/templates/include/registProductList_js.html
+++ b/src/main/resources/templates/include/registProductList_js.html
@@ -79,17 +79,26 @@ function unRegistProduct(){
 
     $(document).on('click', '#section_wrap > div.product_list > table tbody tr td a.unRegist', function(e){
 
-        let no = $(this).data('no'); // data-no 속성에서 값을 가져옴
-        let product_name = $(this).data('product_name'); // data-product_name 속성에서 값을 가져옴
-        let result = confirm('정말 ' + product_name + ' 을(를) 삭제하시겠습니까?');
+        let adminId = $(this).data('adminid');
+        let loginedId = $(this).data('loginedid');
+        if(adminId == loginedId) {   //등록자와 로그인한 사람이 같아야 삭제가능
+            let no = $(this).data('no'); // data-no 속성에서 값을 가져옴
+            let product_name = $(this).data('product_name'); // data-product_name 속성에서 값을 가져옴
+            let result = confirm('정말 ' + product_name + ' 을(를) 삭제하시겠습니까?');
 
-        if (result) {
-            // URL에 파라미터를 추가하여 새로운 URL 생성
-            let newUrl = '/product/unRegistProduct?no=' + no;
+            if (result) {
+                // URL에 파라미터를 추가하여 새로운 URL 생성
+                let newUrl = '/product/unRegistProduct?no=' + no;
 
-            // 새로운 URL로 이동
-            location.href = newUrl;
+                // 새로운 URL로 이동
+                location.href = newUrl;
+            }
         }
+        else{
+            alert('삭제 권한이 없습니다.');
+        }
+
+
 
     })
 }

--- a/src/main/resources/templates/product/adminProductForm.html
+++ b/src/main/resources/templates/product/adminProductForm.html
@@ -26,8 +26,8 @@
 
   <div id="adminProductForm">
     <form th:action="@{/product/adminProductConfirm}" name="adminProductForm" method="post" enctype="multipart/form-data">
-      <input type="hidden" name="admin_id" th:value="${loginedMemberDto.id}">
-      <input type="hidden" name="admin_name" th:value="${loginedMemberDto.name}">
+      <input type="hidden" name="admin_id" th:value="${session.loginedMemberDto.id}">
+      <input type="hidden" name="admin_name" th:value="${session.loginedMemberDto.name}">
 
       <input type="text" name="name" placeholder="INPUT PRODUCT NAME"><br>
       <input type="text" name="price" placeholder="INPUT PRODUCT PRICE"><br>

--- a/src/main/resources/templates/product/adminProductList.html
+++ b/src/main/resources/templates/product/adminProductList.html
@@ -74,7 +74,9 @@
             <a class="unRegist"
                href="#none"
                th:data-no="${productDto.no}"
-               th:data-product_name="${productDto.name}">
+               th:data-product_name="${productDto.name}"
+               th:data-adminid="${productDto.admin_id}"
+               th:data-loginedid="${session.loginedMemberDto.id}">
               삭제
             </a>
           </td>

--- a/src/main/resources/templates/product/productHome.html
+++ b/src/main/resources/templates/product/productHome.html
@@ -18,24 +18,25 @@
     상품 페이지
   </div>
 
-  <div class="right-section">
-    <a th:href="@{/product/productNotice}">상품 공지 (전체 관리자용)</a>
+  <!-- 등급은 000. 001. 002. 003 이 있다. -->
+  <div th:if="${session.loginedMemberDto != null}">
+    <a th:href="@{/product/productNotice}">상품 공지 (전체 관리자용 + 교직원)</a>
   </div>
 
-  <div class="right-section">
+  <div th:if="${session.loginedMemberDto.grade == 'admin000'}">
     <a th:href="@{/product/adminProductForm}">상품 등록 (최종 관리자용)</a>
   </div>
 
-  <div class="right-section">
+  <div th:if="${session.loginedMemberDto.grade == 'admin000'}">
     <a th:href="@{/product/adminProductList}">상품 리스트 (최종 관리자용)</a>
   </div>
 
-  <div class="right-section">
+  <div th:if="${session.loginedMemberDto.grade == 'admin001'}">
     <a th:href="@{/product/registProductForm}">상품 등록 (학교 관리자용)</a>
   </div>
 
-  <div class="right-section">
-    <a th:href="@{/product/registProductList}">개시 상품 리스트 (학교 관리자용)</a>
+  <div th:if="${session.loginedMemberDto.grade == 'admin001' or session.loginedMemberDto.grade == 'admin002'}">
+    <a th:href="@{/product/registProductList}">개시 상품 리스트 (학교 관리자용 + 교직원)</a>
   </div>
 
 </div>

--- a/src/main/resources/templates/product/registProductForm.html
+++ b/src/main/resources/templates/product/registProductForm.html
@@ -25,7 +25,9 @@
 
 <div class="flex-container">
   <div>
-    상품 등록 페이지 (학교 관리자용)
+    <span th:text="${schoolDto.school_name}"></span><br>
+    등록 상품 리스트<br>
+    (학교 관리자용)
   </div>
 
   <div id="registProductForm">
@@ -48,10 +50,10 @@
 
   <div id="registProduct">
     <form th:action="@{/product/registProductConfirm}" name="registProductForm" method="post">
-      <input type="hidden" name="school_no" th:value="${loginedMemberDto.school_no}">
-      <input type="hidden" name="admin_id" th:value="${loginedMemberDto.id}">
-      <input type="hidden" name="admin_name" th:value="${loginedMemberDto.name}">
-      <input type="hidden" name="admin_grade" th:value="${loginedMemberDto.grade}">
+      <input type="hidden" name="school_no" th:value="${session.loginedMemberDto.school_no}">
+      <input type="hidden" name="admin_id" th:value="${session.loginedMemberDto.id}">
+      <input type="hidden" name="admin_name" th:value="${session.loginedMemberDto.name}">
+      <input type="hidden" name="admin_grade" th:value="${session.loginedMemberDto.grade}">
 
       <input type="button" value="regist product" onclick="registProductConfirm();">
     </form>

--- a/src/main/resources/templates/product/registProductList.html
+++ b/src/main/resources/templates/product/registProductList.html
@@ -23,6 +23,7 @@
 
     <!-- WORD START -->
     <div class="word">
+      <span th:text="${schoolDto.school_name}"></span><br>
       등록 상품 리스트 (학교 관리자용)<br>
       total &nbsp;&nbsp; <span th:text="${pageMakerDto.total}"></span>
     </div>
@@ -56,7 +57,7 @@
         </thead>
 
         <tbody>
-        <tr th:each="productRegistDto : ${productRegistDtos}">
+        <tr th:if="${#lists.size(productRegistDtos) > 0}" th:each="productRegistDto : ${productRegistDtos}">
           <td th:text="${productRegistDto.no}"></td>
           <td>
             <img width="100" height="100" th:src="@{'/dormEaseUploadImg/admin/product/' + ${productRegistDto.img}}"
@@ -70,10 +71,16 @@
             <a class="unRegist"
                href="#none"
                th:data-no="${productRegistDto.no}"
-               th:data-product_name="${productRegistDto.product_name}">
+               th:data-product_name="${productRegistDto.product_name}"
+               th:data-adminid="${productRegistDto.admin_id}"
+               th:data-loginedid="${session.loginedMemberDto.id}">
               삭제
             </a>
           </td>
+        </tr>
+
+        <tr th:unless="${#lists.size(productRegistDtos) > 0}">
+          <td colspan="7">등록된 상품이 없습니다.</td>
         </tr>
         </tbody>
       </table>


### PR DESCRIPTION
[등급에 따른 상품 관련 기능]
admin_000 : 최종 관리자용 (상품 등록, 상품 리스트, 상품 공지)
admin_001 : 학교 관리자용 (상품 등록, 상품 리스트, 상품 공지)
admin_002 : 학교 관리자용 (상품 리스트, 상품 공지)
admin_003 : 학교 관리자용 (상품 공지)


[세션 관리]
0. 인터셉트에 product 하위 파일들을 추가하고, 경로를 loginForm으로 수정 및 설정
1. 전체 관리자에 한해 테스트용 관리 세션을 => 로그인 세션으로 변경
2. 상품 등록과 리스트의 관리 세션 변경
3. 뷰로 보내던 테스트 세션을 전부 제거하고, 뷰에서 현재 세션을 체크
4. 각 학교별 등록 및 리스트에 해당 학교를 뷰에 명시
5. 4번 기능을 위한 학교 코드를 통해 학교의 모든 정보를 가져오는 기능 추가
6. 소속 학교에 상품이 등록 되어 있지 않으면 상품이 없다고 표시
    th:if="${#lists.size(productRegistDtos) > 0}" 사용
7. Expected one result (or null) to be returned by selectOne(), but found: 2
   중복 데이터로 인한 문제 해결 => Distinct (zip_code찾기 관련 쿼리)
8. 등록된 상품은 상품 등록자와 로그인한 관리자가 같아야 삭제 가능 처리

